### PR TITLE
Log-transform target variable

### DIFF
--- a/predict_prices/data_prep.py
+++ b/predict_prices/data_prep.py
@@ -150,7 +150,6 @@ def ordinal_transform(df: pd.DataFrame, enc: OrdinalEncoder):
     :return:
     """
     ordinals = list(_ORDERED_CATEGORICALS.keys())
-    print(ordinals[1])
     df[ordinals] = enc.transform(df[ordinals])
 
     return df
@@ -210,7 +209,8 @@ def split_x_y(df: pd.DataFrame, tgt: str, drop=None) -> (
     if drop is None:
         drop = []
     X = df.drop([tgt] + drop, axis=1)
-    y = df[tgt]
+    # The metric of interest is log transformed RMSE
+    y = np.log(df[tgt])
 
     return X, y
 

--- a/predict_prices/main.py
+++ b/predict_prices/main.py
@@ -1,3 +1,4 @@
+import numpy as np
 from sklearn.linear_model import LinearRegression
 
 import cross_validation
@@ -18,7 +19,6 @@ ohe = False
 train_df = data_prep.load_data(train_fp)
 train_df = data_prep.eda_clean(train_df)
 train_df, _ = data_prep.clean_after_eda(train_df)
-# TODO: Save enc into the underscore when we need to use it to transform test data
 ord_enc = data_prep.ordinal_encode(train_df)
 train_df = data_prep.ordinal_transform(train_df, ord_enc)
 cat_enc = data_prep.categorical_encoder(train_df, ohe)
@@ -37,6 +37,7 @@ test_df = data_prep.ordinal_transform(test_df, ord_enc)
 test_df = data_prep.categorical_transform(test_df, cat_enc)
 test_X = test_df if include_categoricals else data_prep.drop_categoricals(test_df)
 
-test_y = lr.predict(test_X)
+# the model was trained against log transformed target. Invert log for predictions
+test_y = np.exp(lr.predict(test_X))
 
 print(test_y[:4])


### PR DESCRIPTION
From the kaggle competition description:

> Submissions are evaluated on [Root-Mean-Squared-Error (RMSE)](https://en.wikipedia.org/wiki/Root-mean-square_deviation) between the logarithm of the predicted value and the logarithm of the observed sales price. (Taking logs means that errors in predicting expensive houses and cheap houses will affect the result equally.)

This sets our model evaluation to pay attention to the metric of interest.